### PR TITLE
Initial wrapper implementation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,16 @@
     "@typescript-eslint"
   ],
   "rules": {
+    "@typescript-eslint/comma-dangle": [
+      "error",
+      {
+        "arrays": "always-multiline",
+        "objects": "always-multiline",
+        "imports": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "never"
+      }
+    ],
     "@typescript-eslint/indent": [
       "error",
       2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "oracle-wrapper",
+  "name": "@seas-computing/oracle-wrapper",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -253,9 +253,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
-      "integrity": "sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
+      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -265,7 +265,7 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -381,9 +381,9 @@
       }
     },
     "@sinonjs/commons": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
-      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.2.tgz",
+      "integrity": "sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -399,9 +399,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.0.tgz",
-      "integrity": "sha512-hXpcfx3aq+ETVBwPlRFICld5EnrkexXuXDwqUNhDdr5L8VjvMeSRwyOa0qL7XFmR+jVWR4rUZtnxlG7RX72sBg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
+      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
@@ -422,9 +422,9 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
-      "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+      "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==",
       "dev": true
     },
     "@types/json5": {
@@ -440,9 +440,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.20.tgz",
-      "integrity": "sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==",
+      "version": "14.14.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.28.tgz",
+      "integrity": "sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g==",
       "dev": true
     },
     "@types/oracledb": {
@@ -471,85 +471,85 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.12.0.tgz",
-      "integrity": "sha512-wHKj6q8s70sO5i39H2g1gtpCXCvjVszzj6FFygneNFyIAxRvNSVz9GML7XpqrB9t7hNutXw+MHnLN/Ih6uyB8Q==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.1.tgz",
+      "integrity": "sha512-yW2epMYZSpNJXZy22Biu+fLdTG8Mn6b22kR3TqblVk50HGNV8Zya15WAXuQCr8tKw4Qf1BL4QtI6kv6PCkLoJw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.12.0",
-        "@typescript-eslint/scope-manager": "4.12.0",
+        "@typescript-eslint/experimental-utils": "4.15.1",
+        "@typescript-eslint/scope-manager": "4.15.1",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
+        "lodash": "^4.17.15",
         "regexpp": "^3.0.0",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.12.0.tgz",
-      "integrity": "sha512-MpXZXUAvHt99c9ScXijx7i061o5HEjXltO+sbYfZAAHxv3XankQkPaNi5myy0Yh0Tyea3Hdq1pi7Vsh0GJb0fA==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.1.tgz",
+      "integrity": "sha512-9LQRmOzBRI1iOdJorr4jEnQhadxK4c9R2aEAsm7WE/7dq8wkKD1suaV0S/JucTL8QlYUPU1y2yjqg+aGC0IQBQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.12.0",
-        "@typescript-eslint/types": "4.12.0",
-        "@typescript-eslint/typescript-estree": "4.12.0",
+        "@typescript-eslint/scope-manager": "4.15.1",
+        "@typescript-eslint/types": "4.15.1",
+        "@typescript-eslint/typescript-estree": "4.15.1",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.12.0.tgz",
-      "integrity": "sha512-9XxVADAo9vlfjfoxnjboBTxYOiNY93/QuvcPgsiKvHxW6tOZx1W4TvkIQ2jB3k5M0pbFP5FlXihLK49TjZXhuQ==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.15.1.tgz",
+      "integrity": "sha512-V8eXYxNJ9QmXi5ETDguB7O9diAXlIyS+e3xzLoP/oVE4WCAjssxLIa0mqCLsCGXulYJUfT+GV70Jv1vHsdKwtA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.12.0",
-        "@typescript-eslint/types": "4.12.0",
-        "@typescript-eslint/typescript-estree": "4.12.0",
+        "@typescript-eslint/scope-manager": "4.15.1",
+        "@typescript-eslint/types": "4.15.1",
+        "@typescript-eslint/typescript-estree": "4.15.1",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.12.0.tgz",
-      "integrity": "sha512-QVf9oCSVLte/8jvOsxmgBdOaoe2J0wtEmBr13Yz0rkBNkl5D8bfnf6G4Vhox9qqMIoG7QQoVwd2eG9DM/ge4Qg==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.15.1.tgz",
+      "integrity": "sha512-ibQrTFcAm7yG4C1iwpIYK7vDnFg+fKaZVfvyOm3sNsGAerKfwPVFtYft5EbjzByDJ4dj1WD8/34REJfw/9wdVA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.12.0",
-        "@typescript-eslint/visitor-keys": "4.12.0"
+        "@typescript-eslint/types": "4.15.1",
+        "@typescript-eslint/visitor-keys": "4.15.1"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.12.0.tgz",
-      "integrity": "sha512-N2RhGeheVLGtyy+CxRmxdsniB7sMSCfsnbh8K/+RUIXYYq3Ub5+sukRCjVE80QerrUBvuEvs4fDhz5AW/pcL6g==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.15.1.tgz",
+      "integrity": "sha512-iGsaUyWFyLz0mHfXhX4zO6P7O3sExQpBJ2dgXB0G5g/8PRVfBBsmQIc3r83ranEQTALLR3Vko/fnCIVqmH+mPw==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.12.0.tgz",
-      "integrity": "sha512-gZkFcmmp/CnzqD2RKMich2/FjBTsYopjiwJCroxqHZIY11IIoN0l5lKqcgoAPKHt33H2mAkSfvzj8i44Jm7F4w==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.1.tgz",
+      "integrity": "sha512-z8MN3CicTEumrWAEB2e2CcoZa3KP9+SMYLIA2aM49XW3cWIaiVSOAGq30ffR5XHxRirqE90fgLw3e6WmNx5uNw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.12.0",
-        "@typescript-eslint/visitor-keys": "4.12.0",
+        "@typescript-eslint/types": "4.15.1",
+        "@typescript-eslint/visitor-keys": "4.15.1",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.12.0.tgz",
-      "integrity": "sha512-hVpsLARbDh4B9TKYz5cLbcdMIOAoBYgFPCSP9FFS/liSF+b33gVNq8JHY3QGhHNVz85hObvL7BEYLlgx553WCw==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.1.tgz",
+      "integrity": "sha512-tYzaTP9plooRJY8eNlpAewTOqtWW/4ff/5wBjNVaJ0S0wC4Gpq/zDVRTJa5bq2v1pCNQ08xxMCndcvR+h7lMww==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.12.0",
+        "@typescript-eslint/types": "4.15.1",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -718,9 +718,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
-      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
     "brace-expansion": {
@@ -840,14 +840,14 @@
       }
     },
     "chokidar": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
-      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -862,54 +862,14 @@
       "dev": true
     },
     "cliui": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
       "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        }
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       }
     },
     "codecov": {
@@ -1142,6 +1102,12 @@
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
     },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1149,13 +1115,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.17.0.tgz",
-      "integrity": "sha512-zJk08MiBgwuGoxes5sSQhOtibZ75pz0J35XTRlZOk9xMffhpA9BTbQZxoXZzOl5zMbleShbGwtw+1kGferfFwQ==",
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.20.0.tgz",
+      "integrity": "sha512-qGi0CTcOGP2OtCQBgWZlQjcTuP0XkIpYFj25XtRTQSHC+umNnp7UMshr2G8SLsRFYDdAPFeHOsiteadmMH02Yw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@eslint/eslintrc": "^0.2.2",
+        "@babel/code-frame": "7.12.11",
+        "@eslint/eslintrc": "^0.3.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -1166,7 +1132,7 @@
         "eslint-utils": "^2.1.0",
         "eslint-visitor-keys": "^2.0.0",
         "espree": "^7.3.1",
-        "esquery": "^1.2.0",
+        "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "file-entry-cache": "^6.0.0",
         "functional-red-black-tree": "^1.0.1",
@@ -1179,7 +1145,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -1202,92 +1168,36 @@
       }
     },
     "eslint-config-airbnb": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.0.tgz",
-      "integrity": "sha512-Fz4JIUKkrhO0du2cg5opdyPKQXOI2MvF8KUvN2710nJMT6jaRUpRE2swrJftAjVGL7T1otLM5ieo5RqS1v9Udg==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
+      "integrity": "sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "^14.2.0",
-        "object.assign": "^4.1.0",
+        "eslint-config-airbnb-base": "^14.2.1",
+        "object.assign": "^4.1.2",
         "object.entries": "^1.1.2"
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.0.tgz",
-      "integrity": "sha512-Snswd5oC6nJaevs3nZoLSTvGJBvzTfnBqOIArkf3cbyTyq9UD79wOk8s+RiL6bhca0p/eRO6veczhf6A/7Jy8Q==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
+      "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
       "dev": true,
       "requires": {
-        "confusing-browser-globals": "^1.0.9",
-        "object.assign": "^4.1.0",
+        "confusing-browser-globals": "^1.0.10",
+        "object.assign": "^4.1.2",
         "object.entries": "^1.1.2"
       }
     },
     "eslint-config-airbnb-typescript": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-12.0.0.tgz",
-      "integrity": "sha512-TUCVru1Z09eKnVAX5i3XoNzjcCOU3nDQz2/jQGkg1jVYm+25fKClveziSl16celfCq+npU0MBPW/ZnXdGFZ9lw==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-typescript/-/eslint-config-airbnb-typescript-12.3.1.tgz",
+      "integrity": "sha512-ql/Pe6/hppYuRp4m3iPaHJqkBB7dgeEmGPQ6X0UNmrQOfTF+dXw29/ZjU2kQ6RDoLxaxOA+Xqv07Vbef6oVTWw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/parser": "4.4.1",
-        "eslint-config-airbnb": "18.2.0",
-        "eslint-config-airbnb-base": "14.2.0"
-      },
-      "dependencies": {
-        "@typescript-eslint/parser": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.4.1.tgz",
-          "integrity": "sha512-S0fuX5lDku28Au9REYUsV+hdJpW/rNW0gWlc4SXzF/kdrRaAVX9YCxKpziH7djeWT/HFAjLZcnY7NJD8xTeUEg==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/scope-manager": "4.4.1",
-            "@typescript-eslint/types": "4.4.1",
-            "@typescript-eslint/typescript-estree": "4.4.1",
-            "debug": "^4.1.1"
-          }
-        },
-        "@typescript-eslint/scope-manager": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.4.1.tgz",
-          "integrity": "sha512-2oD/ZqD4Gj41UdFeWZxegH3cVEEH/Z6Bhr/XvwTtGv66737XkR4C9IqEkebCuqArqBJQSj4AgNHHiN1okzD/wQ==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.4.1",
-            "@typescript-eslint/visitor-keys": "4.4.1"
-          }
-        },
-        "@typescript-eslint/types": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.4.1.tgz",
-          "integrity": "sha512-KNDfH2bCyax5db+KKIZT4rfA8rEk5N0EJ8P0T5AJjo5xrV26UAzaiqoJCxeaibqc0c/IvZxp7v2g3difn2Pn3w==",
-          "dev": true
-        },
-        "@typescript-eslint/typescript-estree": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.4.1.tgz",
-          "integrity": "sha512-wP/V7ScKzgSdtcY1a0pZYBoCxrCstLrgRQ2O9MmCUZDtmgxCO/TCqOTGRVwpP4/2hVfqMz/Vw1ZYrG8cVxvN3g==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.4.1",
-            "@typescript-eslint/visitor-keys": "4.4.1",
-            "debug": "^4.1.1",
-            "globby": "^11.0.1",
-            "is-glob": "^4.0.1",
-            "lodash": "^4.17.15",
-            "semver": "^7.3.2",
-            "tsutils": "^3.17.1"
-          }
-        },
-        "@typescript-eslint/visitor-keys": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.4.1.tgz",
-          "integrity": "sha512-H2JMWhLaJNeaylSnMSQFEhT/S/FsJbebQALmoJxMPMxLtlVAMy2uJP/Z543n9IizhjRayLSqoInehCeNW9rWcw==",
-          "dev": true,
-          "requires": {
-            "@typescript-eslint/types": "4.4.1",
-            "eslint-visitor-keys": "^2.0.0"
-          }
-        }
+        "@typescript-eslint/parser": "^4.4.1",
+        "eslint-config-airbnb": "^18.2.0",
+        "eslint-config-airbnb-base": "^14.2.0"
       }
     },
     "eslint-import-resolver-node": {
@@ -1461,9 +1371,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
-      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -1513,9 +1423,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
-      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -1539,9 +1449,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.0.tgz",
-      "integrity": "sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.10.1.tgz",
+      "integrity": "sha512-AWuv6Ery3pM+dY7LYS8YIaCiQvUaos9OB1RyNgaOWnaX+Tik7Onvcsf8x8c+YtDeT0maYLniBip2hox5KtEXXA==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -1662,9 +1572,9 @@
       }
     },
     "flatted": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz",
-      "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
     },
     "foreground-child": {
@@ -1684,15 +1594,15 @@
       "dev": true
     },
     "fs-extra": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
       }
     },
     "fs.realpath": {
@@ -1702,9 +1612,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
     },
@@ -1808,9 +1718,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.7.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-      "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+      "version": "4.7.7",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
@@ -2252,14 +2162,6 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
-      },
-      "dependencies": {
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
-        }
       }
     },
     "just-extend": {
@@ -2366,9 +2268,9 @@
       "dev": true
     },
     "marked": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.7.tgz",
-      "integrity": "sha512-No11hFYcXr/zkBvL6qFmAp1z6BKY3zqLMHny/JN/ey+al7qwCM2+CMBL9BOgqMxZU36fz4cCWfn2poWIf7QRXA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.0.tgz",
+      "integrity": "sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q==",
       "dev": true
     },
     "merge2": {
@@ -2403,46 +2305,49 @@
       "dev": true
     },
     "mocha": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
-      "integrity": "sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.3.0.tgz",
+      "integrity": "sha512-TQqyC89V1J/Vxx0DhJIXlq9gbbL9XFNdeLQ1+JsnZsVaSOV1z3tWfw0qZmQJGQRIfkvZcs7snQnZnOCKoldq1Q==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.4.3",
-        "debug": "4.2.0",
-        "diff": "4.0.2",
+        "chokidar": "3.5.1",
+        "debug": "4.3.1",
+        "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
         "glob": "7.1.6",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "3.14.0",
+        "js-yaml": "4.0.0",
         "log-symbols": "4.0.0",
         "minimatch": "3.0.4",
-        "ms": "2.1.2",
-        "nanoid": "3.1.12",
+        "ms": "2.1.3",
+        "nanoid": "3.1.20",
         "serialize-javascript": "5.0.1",
         "strip-json-comments": "3.1.1",
-        "supports-color": "7.2.0",
+        "supports-color": "8.1.1",
         "which": "2.0.2",
         "wide-align": "1.1.3",
-        "workerpool": "6.0.2",
-        "yargs": "13.3.2",
-        "yargs-parser": "13.1.2",
+        "workerpool": "6.1.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "4.0.0",
@@ -2466,6 +2371,15 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "js-yaml": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+          "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
         "locate-path": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2474,6 +2388,12 @@
           "requires": {
             "p-locate": "^5.0.0"
           }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
         },
         "p-limit": {
           "version": "3.1.0",
@@ -2500,9 +2420,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -2517,9 +2437,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
-      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
       "dev": true
     },
     "natural-compare": {
@@ -3016,6 +2936,12 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "queue-microtask": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
+      "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==",
+      "dev": true
+    },
     "ramda": {
       "version": "0.27.1",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
@@ -3146,10 +3072,13 @@
       }
     },
     "run-parallel": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
-      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "safe-buffer": {
       "version": "5.2.1",
@@ -3208,45 +3137,13 @@
       }
     },
     "shiki": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.2.7.tgz",
-      "integrity": "sha512-bwVc7cdtYYHEO9O+XJ8aNOskKRfaQd5Y4ovLRfbQkmiLSUaR+bdlssbZUUhbQ0JAFMYcTcJ5tjG5KtnufttDHQ==",
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.2.tgz",
+      "integrity": "sha512-BjUCxVbxMnvjs8jC4b+BQ808vwjJ9Q8NtLqPwXShZ307HdXiDFYP968ORSVfaTNNSWYDBYdMnVKJ0fYNsoZUBA==",
       "dev": true,
       "requires": {
         "onigasm": "^2.2.5",
-        "shiki-languages": "^0.2.7",
-        "shiki-themes": "^0.2.7",
         "vscode-textmate": "^5.2.0"
-      }
-    },
-    "shiki-languages": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/shiki-languages/-/shiki-languages-0.2.7.tgz",
-      "integrity": "sha512-REmakh7pn2jCn9GDMRSK36oDgqhh+rSvJPo77sdWTOmk44C5b0XlYPwJZcFOMJWUZJE0c7FCbKclw4FLwUKLRw==",
-      "dev": true,
-      "requires": {
-        "vscode-textmate": "^5.2.0"
-      }
-    },
-    "shiki-themes": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/shiki-themes/-/shiki-themes-0.2.7.tgz",
-      "integrity": "sha512-ZMmboDYw5+SEpugM8KGUq3tkZ0vXg+k60XX6NngDK7gc1Sv6YLUlanpvG3evm57uKJvfXsky/S5MzSOTtYKLjA==",
-      "dev": true,
-      "requires": {
-        "json5": "^2.1.0",
-        "vscode-textmate": "^5.2.0"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
       }
     },
     "signal-exit": {
@@ -3256,14 +3153,14 @@
       "dev": true
     },
     "sinon": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.3.tgz",
-      "integrity": "sha512-m+DyAWvqVHZtjnjX/nuShasykFeiZ+nPuEfD4G3gpvKGkXRhkF/6NSt2qN2FjZhfrcHXFzUzI+NLnk+42fnLEw==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
-        "@sinonjs/samsam": "^5.3.0",
+        "@sinonjs/samsam": "^5.3.1",
         "diff": "^4.0.2",
         "nise": "^4.0.4",
         "supports-color": "^7.1.0"
@@ -3494,9 +3391,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
-          "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.1.tgz",
+          "integrity": "sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -3591,9 +3488,9 @@
       "dev": true
     },
     "tsutils": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.19.0.tgz",
-      "integrity": "sha512-A7BaLUPvcQ1cxVu72YfD+UMI3SQPTDv/w4ol6TOwLyI0hwfG9EC+cYlhdflJTmtYTgZ3KqdPSe/otxU4K3kArg==",
+      "version": "3.20.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.20.0.tgz",
+      "integrity": "sha512-RYbuQuvkhuqVeXweWT3tJLKOEJ/UUw9GjNEZGWdrLLlM+611o1gwLHBpxoFJKKl25fLprp2eVthtKs5JOrNeXg==",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -3630,53 +3527,53 @@
       }
     },
     "typedoc": {
-      "version": "0.20.13",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.13.tgz",
-      "integrity": "sha512-SJVFn6NJd5bWJHMPgEkDUrKIEfMbja6ftIJv/tgd0xQZp5cWxGTdEnmRr56+egIQZkAJFB39eDvmNV4Lqqy4Gw==",
+      "version": "0.20.25",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.20.25.tgz",
+      "integrity": "sha512-ZQZnjJPrt0rjp216gp6FQC1QC4ojcoKikhfOJ/51CqaJunVDilRLlIO5tCGWj1tzlYYT9eOGhJv7MF3t7rxSmw==",
       "dev": true,
       "requires": {
         "colors": "^1.4.0",
-        "fs-extra": "^9.0.1",
+        "fs-extra": "^9.1.0",
         "handlebars": "^4.7.6",
         "lodash": "^4.17.20",
         "lunr": "^2.3.9",
-        "marked": "^1.2.5",
+        "marked": "^2.0.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.3",
         "shelljs": "^0.8.4",
-        "shiki": "^0.2.7",
-        "typedoc-default-themes": "0.12.0"
+        "shiki": "^0.9.2",
+        "typedoc-default-themes": "^0.12.7"
       }
     },
     "typedoc-default-themes": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.0.tgz",
-      "integrity": "sha512-0hHBxwmfxE0rkIslOiO39fJyYwaScQEhUIxcpqx3uS1BL3zhFW5oQfUaPx2cv2XLL/GXhYFxhdFLoVmNptbxEQ==",
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.7.tgz",
+      "integrity": "sha512-0XAuGEqID+gon1+fhi4LycOEFM+5Mvm2PjwaiVZNAzU7pn3G2DEpsoXnFOPlLDnHY6ZW0BY0nO7ur9fHOFkBLQ==",
       "dev": true
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
       "dev": true
     },
     "uglify-js": {
-      "version": "3.12.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.4.tgz",
-      "integrity": "sha512-L5i5jg/SHkEqzN18gQMTWsZk3KelRsfD1wUVNqtq0kzqWQqcJjyL8yc1o8hJgRrWqrAl2mUFbhfznEIoi7zi2A==",
+      "version": "3.12.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.12.8.tgz",
+      "integrity": "sha512-fvBeuXOsvqjecUtF/l1dwsrrf5y2BCUk9AOJGzGcm6tE7vegku5u/YvqjyDaAGr422PLoLnrxg3EnRvTqsdC1w==",
       "dev": true,
       "optional": true
     },
     "universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true
     },
     "uri-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -3786,59 +3683,45 @@
       "dev": true
     },
     "workerpool": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
-      "integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
       "dev": true
     },
     "wrap-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "color-convert": "^2.0.1"
           }
         },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "color-name": "~1.1.4"
           }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
         }
       }
     },
@@ -3873,115 +3756,33 @@
       "dev": true
     },
     "yargs": {
-      "version": "13.3.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
       "dev": true,
       "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+        "y18n": {
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+          "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==",
           "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
         }
       }
     },
     "yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      }
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true
     },
     "yargs-unparser": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "oracle-wrapper",
+  "name": "@seas-computing/oracle-wrapper",
   "version": "0.0.0",
   "description": "A lightweight wrapper about the oracledb driver",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -30,24 +30,24 @@
   },
   "devDependencies": {
     "@types/mocha": "^8.2.0",
-    "@types/node": "^14.14.20",
+    "@types/node": "^14.14.28",
     "@types/oracledb": "^5.1.0",
     "@types/sinon": "^9.0.10",
-    "@typescript-eslint/eslint-plugin": "^4.12.0",
-    "@typescript-eslint/parser": "^4.12.0",
+    "@typescript-eslint/eslint-plugin": "^4.15.1",
+    "@typescript-eslint/parser": "^4.15.1",
     "codecov": "^3.8.1",
-    "eslint": "^7.17.0",
-    "eslint-config-airbnb-typescript": "^12.0.0",
+    "eslint": "^7.20.0",
+    "eslint-config-airbnb-typescript": "^12.3.1",
     "eslint-import-resolver-node": "^0.3.4",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-mocha": "^8.0.0",
-    "mocha": "^8.2.1",
+    "mocha": "^8.3.0",
     "nyc": "^15.1.0",
     "oracledb": "^5.1.0",
-    "sinon": "^9.2.3",
+    "sinon": "^9.2.4",
     "ts-node": "^9.1.1",
-    "typedoc": "^0.20.13",
-    "typescript": "^4.1.3"
+    "typedoc": "^0.20.25",
+    "typescript": "^4.1.5"
   },
   "dependencies": {}
 }

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,5 +1,5 @@
 import util from 'util';
-import assert from 'assert';
+import { strictEqual, deepStrictEqual, fail } from 'assert';
 import { stub, SinonStub } from 'sinon';
 import oracledb, { Connection, PoolAttributes } from 'oracledb';
 import OracleWrapper from '../index';
@@ -59,7 +59,7 @@ describe('OracleWrapper', function () {
         });
         it('Should use the alias as the property', function () {
           // eslint-disable-next-line @typescript-eslint/dot-notation
-          assert.strictEqual(aliasedWrapper['alias'], testAlias);
+          strictEqual(aliasedWrapper['alias'], testAlias);
         });
       });
       context('Without a value in options', function () {
@@ -68,7 +68,7 @@ describe('OracleWrapper', function () {
         });
         it('Should use the sid as the alias property', function () {
           // eslint-disable-next-line @typescript-eslint/dot-notation
-          assert.strictEqual(aliasedWrapper['alias'], dummy.dbCredentials.sid);
+          strictEqual(aliasedWrapper['alias'], dummy.dbCredentials.sid);
         });
       });
     });
@@ -84,33 +84,33 @@ describe('OracleWrapper', function () {
         it('Should attempt to create a new connection pool', async function () {
           try {
             await wrapper.getConnection();
-            assert.fail();
+            fail();
           } catch (error) {
-            assert.strictEqual(createPoolStub.callCount, 1);
+            strictEqual(createPoolStub.callCount, 1);
           }
         });
         it('Should use the alias from options', async function () {
           try {
             await wrapper.getConnection();
-            assert.fail();
+            fail();
           } catch (error) {
             const { poolAlias } = createPoolStub.args[0][0] as PoolAttributes;
-            assert.strictEqual(poolAlias, options.alias);
+            strictEqual(poolAlias, options.alias);
           }
         });
         it('Should use the credentials', async function () {
           try {
             await wrapper.getConnection();
-            assert.fail();
+            fail();
           } catch (error) {
             const {
               user,
               password,
               connectionString,
             } = createPoolStub.args[0][0] as PoolAttributes;
-            assert.strictEqual(user, dummy.user);
-            assert.strictEqual(password, dummy.password);
-            assert.strictEqual(
+            strictEqual(user, dummy.user);
+            strictEqual(password, dummy.password);
+            strictEqual(
               connectionString,
               `${dummy.host}:${dummy.port}/${dummy.sid}`
             );
@@ -119,22 +119,22 @@ describe('OracleWrapper', function () {
         it('Should log an error notice', async function () {
           try {
             await wrapper.getConnection();
-            assert.fail();
+            fail();
           } catch (error) {
-            assert.strictEqual(testLogger.error.callCount, 2);
-            assert.strictEqual(
+            strictEqual(testLogger.error.callCount, 2);
+            strictEqual(
               testLogger.error.args[0][0],
               'Failed to create connectionPool'
             );
-            assert.strictEqual(testLogger.error.args[1][0], testError);
+            strictEqual(testLogger.error.args[1][0], testError);
           }
         });
         it('Should throw the error', async function () {
           try {
             await wrapper.getConnection();
-            assert.fail();
+            fail();
           } catch (error) {
-            assert.deepStrictEqual(error, testError);
+            deepStrictEqual(error, testError);
           }
         });
       });
@@ -149,35 +149,35 @@ describe('OracleWrapper', function () {
           it('Should call getConnection', async function () {
             try {
               await wrapper.getConnection();
-              assert.fail();
+              fail();
             } catch (error) {
-              assert.strictEqual(getConnectionStub.callCount, 1);
+              strictEqual(getConnectionStub.callCount, 1);
             }
           });
           it('Should use the alias from the options', async function () {
             try {
               await wrapper.getConnection();
-              assert.fail();
+              fail();
             } catch (error) {
-              assert.strictEqual(getConnectionStub.args[0][0], options.alias);
+              strictEqual(getConnectionStub.args[0][0], options.alias);
             }
           });
           it('Should log a message about the error', async function () {
             try {
               await wrapper.getConnection();
-              assert.fail();
+              fail();
             } catch (error) {
-              assert.strictEqual(testLogger.error.callCount, 2);
-              assert.strictEqual(testLogger.error.args[0][0], 'Failed to get connection');
-              assert.strictEqual(testLogger.error.args[1][0], testError);
+              strictEqual(testLogger.error.callCount, 2);
+              strictEqual(testLogger.error.args[0][0], 'Failed to get connection');
+              strictEqual(testLogger.error.args[1][0], testError);
             }
           });
           it('Should throw the error', async function () {
             try {
               await wrapper.getConnection();
-              assert.fail();
+              fail();
             } catch (error) {
-              assert.deepStrictEqual(error, testError);
+              deepStrictEqual(error, testError);
             }
           });
         });
@@ -189,11 +189,11 @@ describe('OracleWrapper', function () {
             result = await wrapper.getConnection();
           });
           it('Should attempt to create a new connection pool', function () {
-            assert.strictEqual(createPoolStub.callCount, 1);
+            strictEqual(createPoolStub.callCount, 1);
           });
           it('Should use the alias from options', function () {
             const { poolAlias } = createPoolStub.args[0][0] as PoolAttributes;
-            assert.strictEqual(poolAlias, options.alias);
+            strictEqual(poolAlias, options.alias);
           });
           it('Should use the credentials', function () {
             const {
@@ -201,21 +201,21 @@ describe('OracleWrapper', function () {
               password,
               connectionString,
             } = createPoolStub.args[0][0] as PoolAttributes;
-            assert.strictEqual(user, dummy.user);
-            assert.strictEqual(password, dummy.password);
-            assert.strictEqual(
+            strictEqual(user, dummy.user);
+            strictEqual(password, dummy.password);
+            strictEqual(
               connectionString,
               `${dummy.host}:${dummy.port}/${dummy.sid}`
             );
           });
           it('Should call getConnection', function () {
-            assert.strictEqual(getConnectionStub.callCount, 1);
+            strictEqual(getConnectionStub.callCount, 1);
           });
           it('Should use the alias from the options', function () {
-            assert.strictEqual(getConnectionStub.args[0][0], options.alias);
+            strictEqual(getConnectionStub.args[0][0], options.alias);
           });
           it('Should reuturn the result', function () {
-            assert.deepStrictEqual(result, dbConnection);
+            deepStrictEqual(result, dbConnection);
           });
         });
       });
@@ -230,11 +230,11 @@ describe('OracleWrapper', function () {
       });
       it('Should not call createPool again', async function () {
         await wrapper.getConnection();
-        assert.strictEqual(createPoolStub.callCount, 0);
+        strictEqual(createPoolStub.callCount, 0);
       });
       it('Should call getConnection', async function () {
         await wrapper.getConnection();
-        assert.strictEqual(getConnectionStub.callCount, 1);
+        strictEqual(getConnectionStub.callCount, 1);
       });
     });
   });
@@ -249,11 +249,11 @@ describe('OracleWrapper', function () {
         return wrapper.releasePool();
       });
       it('Should not call connectionPool.close', function () {
-        assert.strictEqual(connectionPool.close.callCount, 0);
+        strictEqual(connectionPool.close.callCount, 0);
       });
       it('Should not log anything', function () {
         Object.values(testLogger).forEach((logStub) => {
-          assert.strictEqual(logStub.callCount, 0);
+          strictEqual(logStub.callCount, 0);
         });
       });
     });
@@ -268,30 +268,30 @@ describe('OracleWrapper', function () {
         it('Should call connectionPool.close', async function () {
           try {
             await wrapper.releasePool();
-            assert.fail();
+            fail();
           } catch (error) {
-            assert.strictEqual(connectionPool.close.callCount, 1);
+            strictEqual(connectionPool.close.callCount, 1);
           }
         });
         it('Should log an error message', async function () {
           try {
             await wrapper.releasePool();
-            assert.fail();
+            fail();
           } catch (error) {
-            assert.strictEqual(testLogger.error.callCount, 2);
-            assert.strictEqual(
+            strictEqual(testLogger.error.callCount, 2);
+            strictEqual(
               testLogger.error.args[0][0],
               'Could not release pool'
             );
-            assert.strictEqual(testLogger.error.args[1][0], testError);
+            strictEqual(testLogger.error.args[1][0], testError);
           }
         });
         it('Should rethrow the error', async function () {
           try {
             await wrapper.releasePool();
-            assert.fail();
+            fail();
           } catch (error) {
-            assert.strictEqual(error, testError);
+            strictEqual(error, testError);
           }
         });
       });
@@ -301,11 +301,11 @@ describe('OracleWrapper', function () {
           return wrapper.releasePool();
         });
         it('Should call connectionPool.close', function () {
-          assert.strictEqual(connectionPool.close.callCount, 1);
+          strictEqual(connectionPool.close.callCount, 1);
         });
         it('Should log a message about the connection pool releasing', function () {
-          assert.strictEqual(testLogger.info.callCount, 1);
-          assert.strictEqual(
+          strictEqual(testLogger.info.callCount, 1);
+          strictEqual(
             testLogger.info.args[0][0],
             'Connection pool released'
           );
@@ -328,14 +328,14 @@ describe('OracleWrapper', function () {
       it('Should log the query and variables to the debug channel', async function () {
         try {
           await wrapper.query(dummy.queryWithParameters, dummy.queryParameters);
-          assert.fail();
+          fail();
         } catch (err) {
-          assert.strictEqual(testLogger.debug.callCount, 2);
-          assert.strictEqual(
+          strictEqual(testLogger.debug.callCount, 2);
+          strictEqual(
             testLogger.debug.args[0][0],
             `Executing Query: ${dummy.queryWithParameters}`
           );
-          assert.strictEqual(
+          strictEqual(
             testLogger.debug.args[1][0],
             `Parameters: ${util.inspect(dummy.queryParameters)}`
           );
@@ -344,35 +344,35 @@ describe('OracleWrapper', function () {
       it('Should attempt to execute the query', async function () {
         try {
           await wrapper.query(dummy.queryWithParameters, dummy.queryParameters);
-          assert.fail();
+          fail();
         } catch (err) {
-          assert.strictEqual(dbConnection.execute.callCount, 1);
+          strictEqual(dbConnection.execute.callCount, 1);
         }
       });
       it('Should log an error message', async function () {
         try {
           await wrapper.query(dummy.queryWithParameters, dummy.queryParameters);
-          assert.fail();
+          fail();
         } catch (err) {
-          assert.strictEqual(testLogger.error.callCount, 2);
-          assert.strictEqual(testLogger.error.args[0][0], 'Query failed');
-          assert.strictEqual(testLogger.error.args[1][0], testError);
+          strictEqual(testLogger.error.callCount, 2);
+          strictEqual(testLogger.error.args[0][0], 'Query failed');
+          strictEqual(testLogger.error.args[1][0], testError);
         }
       });
       it('Should release the connection', async function () {
         try {
           await wrapper.query(dummy.queryWithParameters, dummy.queryParameters);
-          assert.fail();
+          fail();
         } catch (err) {
-          assert.strictEqual(dbConnection.release.callCount, 1);
+          strictEqual(dbConnection.release.callCount, 1);
         }
       });
       it('Should throw the error', async function () {
         try {
           await wrapper.query(dummy.queryWithParameters, dummy.queryParameters);
-          assert.fail();
+          fail();
         } catch (err) {
-          assert.strictEqual(err, testError);
+          strictEqual(err, testError);
         }
       });
     });
@@ -390,11 +390,11 @@ describe('OracleWrapper', function () {
               dummy.queryWithParameters,
               dummy.queryParameters
             );
-            assert.fail();
+            fail();
           } catch (err) {
-            assert.strictEqual(testLogger.error.callCount, 2);
-            assert.strictEqual(testLogger.error.args[0][0], 'Error fetching data from query');
-            assert.strictEqual(testLogger.error.args[1][0], testError);
+            strictEqual(testLogger.error.callCount, 2);
+            strictEqual(testLogger.error.args[0][0], 'Error fetching data from query');
+            strictEqual(testLogger.error.args[1][0], testError);
           }
         });
         it('Should close the result set', async function () {
@@ -403,9 +403,9 @@ describe('OracleWrapper', function () {
               dummy.queryWithParameters,
               dummy.queryParameters
             );
-            assert.fail();
+            fail();
           } catch (err) {
-            assert.strictEqual(queryResult.resultSet.close.callCount, 1);
+            strictEqual(queryResult.resultSet.close.callCount, 1);
           }
         });
         it('Should release the connection', async function () {
@@ -414,9 +414,9 @@ describe('OracleWrapper', function () {
               dummy.queryWithParameters,
               dummy.queryParameters
             );
-            assert.fail();
+            fail();
           } catch (err) {
-            assert.strictEqual(dbConnection.release.callCount, 1);
+            strictEqual(dbConnection.release.callCount, 1);
           }
         });
         it('Should throw the error', async function () {
@@ -425,9 +425,9 @@ describe('OracleWrapper', function () {
               dummy.queryWithParameters,
               dummy.queryParameters
             );
-            assert.fail();
+            fail();
           } catch (err) {
-            assert.strictEqual(err, testError);
+            strictEqual(err, testError);
           }
         });
       });
@@ -450,14 +450,14 @@ describe('OracleWrapper', function () {
             );
           });
           it('should close the resultSet', function () {
-            assert.strictEqual(queryResult.resultSet.close.callCount, 1);
+            strictEqual(queryResult.resultSet.close.callCount, 1);
           });
           it('should close the connection', function () {
-            assert.strictEqual(dbConnection.release.callCount, 1);
+            strictEqual(dbConnection.release.callCount, 1);
           });
           it('should return the full set of results', function () {
-            assert.strictEqual(queryResult.resultSet.getRows.callCount, 3);
-            assert.deepStrictEqual(results, dummy.queryResults);
+            strictEqual(queryResult.resultSet.getRows.callCount, 3);
+            deepStrictEqual(results, dummy.queryResults);
           });
         });
         context('without Variables', function () {
@@ -465,14 +465,14 @@ describe('OracleWrapper', function () {
             results = await wrapper.query(dummy.queryWithoutParameters);
           });
           it('should close the resultSet', function () {
-            assert.strictEqual(queryResult.resultSet.close.callCount, 1);
+            strictEqual(queryResult.resultSet.close.callCount, 1);
           });
           it('should close the connection', function () {
-            assert.strictEqual(dbConnection.release.callCount, 1);
+            strictEqual(dbConnection.release.callCount, 1);
           });
           it('should return the full set of results', function () {
-            assert.strictEqual(queryResult.resultSet.getRows.callCount, 3);
-            assert.deepStrictEqual(results, dummy.queryResults);
+            strictEqual(queryResult.resultSet.getRows.callCount, 3);
+            deepStrictEqual(results, dummy.queryResults);
           });
         });
       });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -84,7 +84,7 @@ describe('OracleWrapper', function () {
         it('Should attempt to create a new connection pool', async function () {
           try {
             await wrapper.getConnection();
-            fail();
+            fail('Did not throw an error');
           } catch (error) {
             strictEqual(createPoolStub.callCount, 1);
           }
@@ -92,7 +92,7 @@ describe('OracleWrapper', function () {
         it('Should use the alias from options', async function () {
           try {
             await wrapper.getConnection();
-            fail();
+            fail('Did not throw an error');
           } catch (error) {
             const { poolAlias } = createPoolStub.args[0][0] as PoolAttributes;
             strictEqual(poolAlias, options.alias);
@@ -101,7 +101,7 @@ describe('OracleWrapper', function () {
         it('Should use the credentials', async function () {
           try {
             await wrapper.getConnection();
-            fail();
+            fail('Did not throw an error');
           } catch (error) {
             const {
               user,
@@ -119,7 +119,7 @@ describe('OracleWrapper', function () {
         it('Should log an error notice', async function () {
           try {
             await wrapper.getConnection();
-            fail();
+            fail('Did not throw an error');
           } catch (error) {
             strictEqual(testLogger.error.callCount, 2);
             strictEqual(
@@ -132,7 +132,7 @@ describe('OracleWrapper', function () {
         it('Should throw the error', async function () {
           try {
             await wrapper.getConnection();
-            fail();
+            fail('Did not throw an error');
           } catch (error) {
             deepStrictEqual(error, testError);
           }
@@ -149,7 +149,7 @@ describe('OracleWrapper', function () {
           it('Should call getConnection', async function () {
             try {
               await wrapper.getConnection();
-              fail();
+              fail('Did not throw an error');
             } catch (error) {
               strictEqual(getConnectionStub.callCount, 1);
             }
@@ -157,7 +157,7 @@ describe('OracleWrapper', function () {
           it('Should use the alias from the options', async function () {
             try {
               await wrapper.getConnection();
-              fail();
+              fail('Did not throw an error');
             } catch (error) {
               strictEqual(getConnectionStub.args[0][0], options.alias);
             }
@@ -165,7 +165,7 @@ describe('OracleWrapper', function () {
           it('Should log a message about the error', async function () {
             try {
               await wrapper.getConnection();
-              fail();
+              fail('Did not throw an error');
             } catch (error) {
               strictEqual(testLogger.error.callCount, 2);
               strictEqual(testLogger.error.args[0][0], 'Failed to get connection');
@@ -175,7 +175,7 @@ describe('OracleWrapper', function () {
           it('Should throw the error', async function () {
             try {
               await wrapper.getConnection();
-              fail();
+              fail('Did not throw an error');
             } catch (error) {
               deepStrictEqual(error, testError);
             }
@@ -268,7 +268,7 @@ describe('OracleWrapper', function () {
         it('Should call connectionPool.close', async function () {
           try {
             await wrapper.releasePool();
-            fail();
+            fail('Did not throw an error');
           } catch (error) {
             strictEqual(connectionPool.close.callCount, 1);
           }
@@ -276,7 +276,7 @@ describe('OracleWrapper', function () {
         it('Should log an error message', async function () {
           try {
             await wrapper.releasePool();
-            fail();
+            fail('Did not throw an error');
           } catch (error) {
             strictEqual(testLogger.error.callCount, 2);
             strictEqual(
@@ -289,7 +289,7 @@ describe('OracleWrapper', function () {
         it('Should rethrow the error', async function () {
           try {
             await wrapper.releasePool();
-            fail();
+            fail('Did not throw an error');
           } catch (error) {
             strictEqual(error, testError);
           }
@@ -328,7 +328,7 @@ describe('OracleWrapper', function () {
       it('Should log the query and variables to the debug channel', async function () {
         try {
           await wrapper.query(dummy.queryWithParameters, dummy.queryParameters);
-          fail();
+          fail('Did not throw an error');
         } catch (err) {
           strictEqual(testLogger.debug.callCount, 2);
           strictEqual(
@@ -344,7 +344,7 @@ describe('OracleWrapper', function () {
       it('Should attempt to execute the query', async function () {
         try {
           await wrapper.query(dummy.queryWithParameters, dummy.queryParameters);
-          fail();
+          fail('Did not throw an error');
         } catch (err) {
           strictEqual(dbConnection.execute.callCount, 1);
         }
@@ -352,7 +352,7 @@ describe('OracleWrapper', function () {
       it('Should log an error message', async function () {
         try {
           await wrapper.query(dummy.queryWithParameters, dummy.queryParameters);
-          fail();
+          fail('Did not throw an error');
         } catch (err) {
           strictEqual(testLogger.error.callCount, 2);
           strictEqual(testLogger.error.args[0][0], 'Query failed');
@@ -362,7 +362,7 @@ describe('OracleWrapper', function () {
       it('Should release the connection', async function () {
         try {
           await wrapper.query(dummy.queryWithParameters, dummy.queryParameters);
-          fail();
+          fail('Did not throw an error');
         } catch (err) {
           strictEqual(dbConnection.release.callCount, 1);
         }
@@ -370,7 +370,7 @@ describe('OracleWrapper', function () {
       it('Should throw the error', async function () {
         try {
           await wrapper.query(dummy.queryWithParameters, dummy.queryParameters);
-          fail();
+          fail('Did not throw an error');
         } catch (err) {
           strictEqual(err, testError);
         }
@@ -390,7 +390,7 @@ describe('OracleWrapper', function () {
               dummy.queryWithParameters,
               dummy.queryParameters
             );
-            fail();
+            fail('Did not throw an error');
           } catch (err) {
             strictEqual(testLogger.error.callCount, 2);
             strictEqual(testLogger.error.args[0][0], 'Error fetching data from query');
@@ -403,7 +403,7 @@ describe('OracleWrapper', function () {
               dummy.queryWithParameters,
               dummy.queryParameters
             );
-            fail();
+            fail('Did not throw an error');
           } catch (err) {
             strictEqual(queryResult.resultSet.close.callCount, 1);
           }
@@ -414,7 +414,7 @@ describe('OracleWrapper', function () {
               dummy.queryWithParameters,
               dummy.queryParameters
             );
-            fail();
+            fail('Did not throw an error');
           } catch (err) {
             strictEqual(dbConnection.release.callCount, 1);
           }
@@ -425,7 +425,7 @@ describe('OracleWrapper', function () {
               dummy.queryWithParameters,
               dummy.queryParameters
             );
-            fail();
+            fail('Did not throw an error');
           } catch (err) {
             strictEqual(err, testError);
           }

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -64,10 +64,6 @@ describe('OracleWrapper', function () {
           // eslint-disable-next-line @typescript-eslint/dot-notation
           assert.strictEqual(aliasedWrapper['alias'], testAlias);
         });
-        it('Should use the alias in the poolCredentials', function () {
-          // eslint-disable-next-line
-          assert.strictEqual(aliasedWrapper['poolCredentials'].poolAlias, testAlias);
-        });
       });
       context('Without a value in options', function () {
         beforeEach(function () {
@@ -76,36 +72,6 @@ describe('OracleWrapper', function () {
         it('Should use the sid as the alias property', function () {
           // eslint-disable-next-line @typescript-eslint/dot-notation
           assert.strictEqual(aliasedWrapper['alias'], credentials.sid);
-        });
-        it('Should use the sid as the poolAlias in the poolCredentials', function () {
-          // eslint-disable-next-line
-          assert.strictEqual(aliasedWrapper['poolCredentials'].poolAlias, credentials.sid);
-        });
-      });
-    });
-    describe('Logger', function () {
-      let aliasedWrapper: OracleWrapper;
-      context('With a value in options', function () {
-        beforeEach(function () {
-          aliasedWrapper = new OracleWrapper(
-            credentials,
-            {
-              logger: testLogger as unknown as Logger,
-            }
-          );
-        });
-        it('Should use the passed-in Logger', function () {
-          // eslint-disable-next-line
-          assert.strictEqual(aliasedWrapper['logger'], testLogger);
-        });
-      });
-      context('Without a value in options', function () {
-        beforeEach(function () {
-          aliasedWrapper = new OracleWrapper(credentials);
-        });
-        it('Should use the Console', function () {
-          // eslint-disable-next-line
-          assert.strictEqual(aliasedWrapper['logger'], console);
         });
       });
     });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -61,7 +61,7 @@ describe('OracleWrapper', function () {
           aliasedWrapper = new OracleWrapper(credentials, { alias: testAlias });
         });
         it('Should use the alias as the property', function () {
-          // eslint-disable-next-line
+          // eslint-disable-next-line @typescript-eslint/dot-notation
           assert.strictEqual(aliasedWrapper['alias'], testAlias);
         });
         it('Should use the alias in the poolCredentials', function () {
@@ -74,7 +74,7 @@ describe('OracleWrapper', function () {
           aliasedWrapper = new OracleWrapper(credentials);
         });
         it('Should use the sid as the alias property', function () {
-          // eslint-disable-next-line
+          // eslint-disable-next-line @typescript-eslint/dot-notation
           assert.strictEqual(aliasedWrapper['alias'], credentials.sid);
         });
         it('Should use the sid as the poolAlias in the poolCredentials', function () {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -158,11 +158,12 @@ describe('OracleWrapper', function () {
             await wrapper.getConnection();
             assert.fail();
           } catch (error) {
-            assert.strictEqual(testLogger.error.callCount, 1);
+            assert.strictEqual(testLogger.error.callCount, 2);
             assert.strictEqual(
               testLogger.error.args[0][0],
               'Failed to create connectionPool'
             );
+            assert.strictEqual(testLogger.error.args[1][0], testError);
           }
         });
         it('Should throw the error', async function () {
@@ -203,8 +204,9 @@ describe('OracleWrapper', function () {
               await wrapper.getConnection();
               assert.fail();
             } catch (error) {
-              assert.strictEqual(testLogger.error.callCount, 1);
+              assert.strictEqual(testLogger.error.callCount, 2);
               assert.strictEqual(testLogger.error.args[0][0], 'Failed to get connection');
+              assert.strictEqual(testLogger.error.args[1][0], testError);
             }
           });
           it('Should throw the error', async function () {
@@ -313,11 +315,12 @@ describe('OracleWrapper', function () {
             await wrapper.releasePool();
             assert.fail();
           } catch (error) {
-            assert.strictEqual(testLogger.error.callCount, 1);
+            assert.strictEqual(testLogger.error.callCount, 2);
             assert.strictEqual(
               testLogger.error.args[0][0],
               'Could not release pool'
             );
+            assert.strictEqual(testLogger.error.args[1][0], testError);
           }
         });
         it('Should rethrow the error', async function () {
@@ -394,8 +397,9 @@ describe('OracleWrapper', function () {
           await wrapper.query(testQuery, testVariables);
           assert.fail();
         } catch (err) {
-          assert.strictEqual(testLogger.error.callCount, 1);
+          assert.strictEqual(testLogger.error.callCount, 2);
           assert.strictEqual(testLogger.error.args[0][0], 'Query failed');
+          assert.strictEqual(testLogger.error.args[1][0], testError);
         }
       });
       it('Should release the connection', async function () {
@@ -428,8 +432,9 @@ describe('OracleWrapper', function () {
             await wrapper.query(testQuery, testVariables);
             assert.fail();
           } catch (err) {
-            assert.strictEqual(testLogger.error.callCount, 1);
+            assert.strictEqual(testLogger.error.callCount, 2);
             assert.strictEqual(testLogger.error.args[0][0], 'Error fetching data from query');
+            assert.strictEqual(testLogger.error.args[1][0], testError);
           }
         });
         it('Should close the result set', async function () {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,0 +1,512 @@
+import util from 'util';
+import assert from 'assert';
+import { stub, SinonStub } from 'sinon';
+import oracledb, { Connection, PoolAttributes } from 'oracledb';
+import OracleWrapper from '../index';
+import { Logger, OracleDBOptions } from '../types';
+
+describe('OracleWrapper', function () {
+  let wrapper: OracleWrapper;
+  let getConnectionStub: SinonStub;
+  let createPoolStub: SinonStub;
+  let connectionPool: Record<string, SinonStub>;
+  let dbConnection: Record<string, SinonStub>;
+  let queryResult: Record<string, Record<string, SinonStub>>;
+  const credentials = {
+    host: '127.0.0.1',
+    port: '1521',
+    sid: 'ORCTEST',
+    user: 'SYSADMIN',
+    password: 'oracledbtest',
+  };
+  let options: OracleDBOptions;
+  let testLogger: Record<string, SinonStub>;
+
+  beforeEach(function () {
+    testLogger = {
+      log: stub(),
+      error: stub(),
+      warn: stub(),
+      info: stub(),
+      debug: stub(),
+      verbose: stub(),
+    };
+    connectionPool = {
+      close: stub(),
+    };
+    dbConnection = {
+      execute: stub(),
+      release: stub(),
+    };
+    queryResult = {
+      resultSet: {
+        getRows: stub(),
+        close: stub(),
+      },
+    };
+    options = {
+      alias: 'TestDB1',
+      logger: testLogger as unknown as Logger,
+    };
+    wrapper = new OracleWrapper(credentials, options);
+    getConnectionStub = stub(oracledb, 'getConnection');
+    createPoolStub = stub(oracledb, 'createPool');
+  });
+  describe('Constructor', function () {
+    describe('Alias', function () {
+      const testAlias = 'TestDB2';
+      let aliasedWrapper: OracleWrapper;
+      context('With a value in options', function () {
+        beforeEach(function () {
+          aliasedWrapper = new OracleWrapper(credentials, { alias: testAlias });
+        });
+        it('Should use the alias as the property', function () {
+          // eslint-disable-next-line
+          assert.strictEqual(aliasedWrapper['alias'], testAlias);
+        });
+        it('Should use the alias in the poolCredentials', function () {
+          // eslint-disable-next-line
+          assert.strictEqual(aliasedWrapper['poolCredentials'].poolAlias, testAlias);
+        });
+      });
+      context('Without a value in options', function () {
+        beforeEach(function () {
+          aliasedWrapper = new OracleWrapper(credentials);
+        });
+        it('Should use the sid as the alias property', function () {
+          // eslint-disable-next-line
+          assert.strictEqual(aliasedWrapper['alias'], credentials.sid);
+        });
+        it('Should use the sid as the poolAlias in the poolCredentials', function () {
+          // eslint-disable-next-line
+          assert.strictEqual(aliasedWrapper['poolCredentials'].poolAlias, credentials.sid);
+        });
+      });
+    });
+    describe('Logger', function () {
+      let aliasedWrapper: OracleWrapper;
+      context('With a value in options', function () {
+        beforeEach(function () {
+          aliasedWrapper = new OracleWrapper(
+            credentials,
+            {
+              logger: testLogger as unknown as Logger,
+            }
+          );
+        });
+        it('Should use the passed-in Logger', function () {
+          // eslint-disable-next-line
+          assert.strictEqual(aliasedWrapper['logger'], testLogger);
+        });
+      });
+      context('Without a value in options', function () {
+        beforeEach(function () {
+          aliasedWrapper = new OracleWrapper(credentials);
+        });
+        it('Should use the Console', function () {
+          // eslint-disable-next-line
+          assert.strictEqual(aliasedWrapper['logger'], console);
+        });
+      });
+    });
+  });
+  describe('getConnection', function () {
+    context('When a connection pool hasn\'t been instantiated', function () {
+      context('When createPool fails', function () {
+        let testError: Error;
+        beforeEach(function () {
+          testError = new Error('createPool failed');
+          createPoolStub.rejects(testError);
+        });
+        it('Should attempt to create a new connection pool', async function () {
+          try {
+            await wrapper.getConnection();
+            assert.fail();
+          } catch (error) {
+            assert.strictEqual(createPoolStub.callCount, 1);
+          }
+        });
+        it('Should use the alias from options', async function () {
+          try {
+            await wrapper.getConnection();
+            assert.fail();
+          } catch (error) {
+            const { poolAlias } = createPoolStub.args[0][0] as PoolAttributes;
+            assert.strictEqual(poolAlias, options.alias);
+          }
+        });
+        it('Should use the credentials', async function () {
+          try {
+            await wrapper.getConnection();
+            assert.fail();
+          } catch (error) {
+            const {
+              user,
+              password,
+              connectionString,
+            } = createPoolStub.args[0][0] as PoolAttributes;
+            assert.strictEqual(user, credentials.user);
+            assert.strictEqual(password, credentials.password);
+            assert.strictEqual(
+              connectionString,
+              `${credentials.host}:${credentials.port}/${credentials.sid}`
+            );
+          }
+        });
+        it('Should log an error notice', async function () {
+          try {
+            await wrapper.getConnection();
+            assert.fail();
+          } catch (error) {
+            assert.strictEqual(testLogger.error.callCount, 1);
+            assert.strictEqual(
+              testLogger.error.args[0][0],
+              'Failed to create connectionPool'
+            );
+          }
+        });
+        it('Should throw the error', async function () {
+          try {
+            await wrapper.getConnection();
+            assert.fail();
+          } catch (error) {
+            assert.deepStrictEqual(error, testError);
+          }
+        });
+      });
+      context('When createPool succeeds', function () {
+        context('When getConnection fails', function () {
+          let testError: Error;
+          beforeEach(function () {
+            testError = new Error('getConnection failed');
+            createPoolStub.resolves(connectionPool);
+            getConnectionStub.rejects(testError);
+          });
+          it('Should call getConnection', async function () {
+            try {
+              await wrapper.getConnection();
+              assert.fail();
+            } catch (error) {
+              assert.strictEqual(getConnectionStub.callCount, 1);
+            }
+          });
+          it('Should use the alias from the options', async function () {
+            try {
+              await wrapper.getConnection();
+              assert.fail();
+            } catch (error) {
+              assert.strictEqual(getConnectionStub.args[0][0], options.alias);
+            }
+          });
+          it('Should log a message about the error', async function () {
+            try {
+              await wrapper.getConnection();
+              assert.fail();
+            } catch (error) {
+              assert.strictEqual(testLogger.error.callCount, 1);
+              assert.strictEqual(testLogger.error.args[0][0], 'Failed to get connection');
+            }
+          });
+          it('Should throw the error', async function () {
+            try {
+              await wrapper.getConnection();
+              assert.fail();
+            } catch (error) {
+              assert.deepStrictEqual(error, testError);
+            }
+          });
+        });
+        context('When getConnection succeeds', function () {
+          let result: Connection;
+          beforeEach(async function () {
+            createPoolStub.resolves(connectionPool);
+            getConnectionStub.resolves(dbConnection);
+            result = await wrapper.getConnection();
+          });
+          it('Should attempt to create a new connection pool', function () {
+            assert.strictEqual(createPoolStub.callCount, 1);
+          });
+          it('Should use the alias from options', function () {
+            const { poolAlias } = createPoolStub.args[0][0] as PoolAttributes;
+            assert.strictEqual(poolAlias, options.alias);
+          });
+          it('Should use the credentials', function () {
+            const {
+              user,
+              password,
+              connectionString,
+            } = createPoolStub.args[0][0] as PoolAttributes;
+            assert.strictEqual(user, credentials.user);
+            assert.strictEqual(password, credentials.password);
+            assert.strictEqual(
+              connectionString,
+              `${credentials.host}:${credentials.port}/${credentials.sid}`
+            );
+          });
+          it('Should call getConnection', function () {
+            assert.strictEqual(getConnectionStub.callCount, 1);
+          });
+          it('Should use the alias from the options', function () {
+            assert.strictEqual(getConnectionStub.args[0][0], options.alias);
+          });
+          it('Should reuturn the result', function () {
+            assert.deepStrictEqual(result, dbConnection);
+          });
+        });
+      });
+    });
+    context('When a connection pool already exists', function () {
+      beforeEach(async function () {
+        createPoolStub.resolves(connectionPool);
+        getConnectionStub.resolves(dbConnection);
+        await wrapper.getConnection();
+        createPoolStub.reset();
+        getConnectionStub.reset();
+      });
+      it('Should not call createPool again', async function () {
+        await wrapper.getConnection();
+        assert.strictEqual(createPoolStub.callCount, 0);
+      });
+      it('Should call getConnection', async function () {
+        await wrapper.getConnection();
+        assert.strictEqual(getConnectionStub.callCount, 1);
+      });
+    });
+  });
+  describe('releasePool', function () {
+    let testError: Error;
+    beforeEach(function () {
+      testError = new Error('Failed to release Pool');
+      createPoolStub.resolves(connectionPool);
+    });
+    context('When there is no connectionPool', function () {
+      beforeEach(async function () {
+        return wrapper.releasePool();
+      });
+      it('Should not call connectionPool.close', function () {
+        assert.strictEqual(connectionPool.close.callCount, 0);
+      });
+      it('Should not log anything', function () {
+        Object.values(testLogger).forEach((logStub) => {
+          assert.strictEqual(logStub.callCount, 0);
+        });
+      });
+    });
+    context('When there is an existing connectionPool', function () {
+      beforeEach(async function () {
+        return wrapper.getConnection();
+      });
+      context('When the pool fails to release', function () {
+        beforeEach(function () {
+          connectionPool.close.rejects(testError);
+        });
+        it('Should call connectionPool.close', async function () {
+          try {
+            await wrapper.releasePool();
+            assert.fail();
+          } catch (error) {
+            assert.strictEqual(connectionPool.close.callCount, 1);
+          }
+        });
+        it('Should log an error message', async function () {
+          try {
+            await wrapper.releasePool();
+            assert.fail();
+          } catch (error) {
+            assert.strictEqual(testLogger.error.callCount, 1);
+            assert.strictEqual(
+              testLogger.error.args[0][0],
+              'Could not release pool'
+            );
+          }
+        });
+        it('Should rethrow the error', async function () {
+          try {
+            await wrapper.releasePool();
+            assert.fail();
+          } catch (error) {
+            assert.strictEqual(error, testError);
+          }
+        });
+      });
+      context('When the pool successfully releases', function () {
+        beforeEach(async function () {
+          connectionPool.close.resolves();
+          return wrapper.releasePool();
+        });
+        it('Should call connectionPool.close', function () {
+          assert.strictEqual(connectionPool.close.callCount, 1);
+        });
+        it('Should log a message about the connection pool releasing', function () {
+          assert.strictEqual(testLogger.info.callCount, 1);
+          assert.strictEqual(
+            testLogger.info.args[0][0],
+            'Connection pool released'
+          );
+        });
+      });
+    });
+  });
+  describe('query', function () {
+    let testError: Error;
+    let testQuery: string;
+    let testQueryWithoutVariables: string;
+    let testVariables: Record<string, string>;
+    beforeEach(function () {
+      testError = new Error('query failed');
+      testQueryWithoutVariables = 'SELECT * FROM USERS;';
+      testQuery = "SELECT * FROM USERS WHERE NAME=':name';";
+      testVariables = { name: 'foo' };
+      dbConnection.release.resolves();
+      stub(OracleWrapper.prototype, 'getConnection')
+        .resolves(dbConnection as unknown as Connection);
+    });
+    context('When initial query fails', function () {
+      beforeEach(function () {
+        dbConnection.execute.rejects(testError);
+      });
+      it('Should log the query and variables to the debug channel', async function () {
+        try {
+          await wrapper.query(testQuery, testVariables);
+          assert.fail();
+        } catch (err) {
+          assert.strictEqual(testLogger.debug.callCount, 2);
+          assert.strictEqual(
+            testLogger.debug.args[0][0],
+            `Executing Query: ${testQuery}`
+          );
+          assert.strictEqual(
+            testLogger.debug.args[1][0],
+            `Parameters: ${util.inspect(testVariables)}`
+          );
+        }
+      });
+      it('Should attempt to execute the query', async function () {
+        try {
+          await wrapper.query(testQuery, testVariables);
+          assert.fail();
+        } catch (err) {
+          assert.strictEqual(dbConnection.execute.callCount, 1);
+        }
+      });
+      it('Should log an error message', async function () {
+        try {
+          await wrapper.query(testQuery, testVariables);
+          assert.fail();
+        } catch (err) {
+          assert.strictEqual(testLogger.error.callCount, 1);
+          assert.strictEqual(testLogger.error.args[0][0], 'Query failed');
+        }
+      });
+      it('Should release the connection', async function () {
+        try {
+          await wrapper.query(testQuery, testVariables);
+          assert.fail();
+        } catch (err) {
+          assert.strictEqual(dbConnection.release.callCount, 1);
+        }
+      });
+      it('Should throw the error', async function () {
+        try {
+          await wrapper.query(testQuery, testVariables);
+          assert.fail();
+        } catch (err) {
+          assert.strictEqual(err, testError);
+        }
+      });
+    });
+    context('When initial query succeeds', function () {
+      context('When response generation fails', function () {
+        beforeEach(function () {
+          testError = new Error('Fetching Rows failed');
+          queryResult.resultSet.close.resolves();
+          queryResult.resultSet.getRows.rejects(testError);
+          dbConnection.execute.resolves(queryResult);
+        });
+        it('Should log an error message', async function () {
+          try {
+            await wrapper.query(testQuery, testVariables);
+            assert.fail();
+          } catch (err) {
+            assert.strictEqual(testLogger.error.callCount, 1);
+            assert.strictEqual(testLogger.error.args[0][0], 'Error fetching data from query');
+          }
+        });
+        it('Should close the result set', async function () {
+          try {
+            await wrapper.query(testQuery, testVariables);
+            assert.fail();
+          } catch (err) {
+            assert.strictEqual(queryResult.resultSet.close.callCount, 1);
+          }
+        });
+        it('Should release the connection', async function () {
+          try {
+            await wrapper.query(testQuery, testVariables);
+            assert.fail();
+          } catch (err) {
+            assert.strictEqual(dbConnection.release.callCount, 1);
+          }
+        });
+        it('Should throw the error', async function () {
+          try {
+            await wrapper.query(testQuery, testVariables);
+            assert.fail();
+          } catch (err) {
+            assert.strictEqual(err, testError);
+          }
+        });
+      });
+      context('When response generation succeeds', function () {
+        let results: Record<string, unknown>[];
+        const fullQueryResults = [
+          { name: 'one' },
+          { name: 'two' },
+          { name: 'three' },
+          { name: 'four' },
+          { name: 'fix' },
+          { name: 'six' },
+        ];
+        beforeEach(function () {
+          queryResult.resultSet.close.resolves();
+          queryResult.resultSet.getRows.onFirstCall()
+            .resolves(fullQueryResults.slice(0, 3));
+          queryResult.resultSet.getRows.onSecondCall()
+            .resolves(fullQueryResults.slice(3, 6));
+          queryResult.resultSet.getRows.onThirdCall().resolves([]);
+          dbConnection.execute.resolves(queryResult);
+        });
+        context('with Variables', function () {
+          beforeEach(async function () {
+            results = await wrapper.query(testQuery, testVariables);
+          });
+          it('should close the resultSet', function () {
+            assert.strictEqual(queryResult.resultSet.close.callCount, 1);
+          });
+          it('should close the connection', function () {
+            assert.strictEqual(dbConnection.release.callCount, 1);
+          });
+          it('should return the full set of results', function () {
+            assert.strictEqual(queryResult.resultSet.getRows.callCount, 3);
+            assert.deepStrictEqual(results, fullQueryResults);
+          });
+        });
+        context('without Variables', function () {
+          beforeEach(async function () {
+            results = await wrapper.query(testQueryWithoutVariables);
+          });
+          it('should close the resultSet', function () {
+            assert.strictEqual(queryResult.resultSet.close.callCount, 1);
+          });
+          it('should close the connection', function () {
+            assert.strictEqual(dbConnection.release.callCount, 1);
+          });
+          it('should return the full set of results', function () {
+            assert.strictEqual(queryResult.resultSet.getRows.callCount, 3);
+            assert.deepStrictEqual(results, fullQueryResults);
+          });
+        });
+      });
+    });
+  });
+});

--- a/src/__tests__/mockData.ts
+++ b/src/__tests__/mockData.ts
@@ -35,7 +35,7 @@ export const dbCredentials = {
 };
 
 /**
- * A fake query without an parameters
+ * A fake query without any parameters
  */
 export const queryWithoutParameters = 'SELECT * FROM users;';
 

--- a/src/__tests__/mockData.ts
+++ b/src/__tests__/mockData.ts
@@ -2,18 +2,22 @@
  * The user name for the connection
  */
 export const user = 'SYSADMIN';
+
 /**
  * The password for the connection
  */
 export const password = 'oracledbtest';
+
 /**
  * The host to connect to
  */
 export const host = '127.0.0.1';
+
 /**
  * The port on which the database is running
  */
 export const port = '1521';
+
 /**
  * The SID for the connection
  */
@@ -22,7 +26,6 @@ export const sid = 'ORCTEST';
 /**
  * Fake Credentials for an OracleDB database
  */
-
 export const dbCredentials = {
   host,
   port,
@@ -34,19 +37,16 @@ export const dbCredentials = {
 /**
  * A fake query without an parameters
  */
-
 export const queryWithoutParameters = 'SELECT * FROM users;';
 
 /**
  * A fake query with parameters
  */
-
 export const queryWithParameters = "SELECT * FROM users WHERE name=':name';";
 
 /**
  * fake parameters to use with the fake query
  */
-
 export const queryParameters = { name: 'three' };
 
 /**

--- a/src/__tests__/mockData.ts
+++ b/src/__tests__/mockData.ts
@@ -1,0 +1,62 @@
+/**
+ * The user name for the connection
+ */
+export const user = 'SYSADMIN';
+/**
+ * The password for the connection
+ */
+export const password = 'oracledbtest';
+/**
+ * The host to connect to
+ */
+export const host = '127.0.0.1';
+/**
+ * The port on which the database is running
+ */
+export const port = '1521';
+/**
+ * The SID for the connection
+ */
+export const sid = 'ORCTEST';
+
+/**
+ * Fake Credentials for an OracleDB database
+ */
+
+export const dbCredentials = {
+  host,
+  port,
+  sid,
+  user,
+  password,
+};
+
+/**
+ * A fake query without an parameters
+ */
+
+export const queryWithoutParameters = 'SELECT * FROM users;';
+
+/**
+ * A fake query with parameters
+ */
+
+export const queryWithParameters = "SELECT * FROM users WHERE name=':name';";
+
+/**
+ * fake parameters to use with the fake query
+ */
+
+export const queryParameters = { name: 'three' };
+
+/**
+ * The fake results from our fake query
+ */
+export const queryResults = [
+  { name: 'one' },
+  { name: 'two' },
+  { name: 'three' },
+  { name: 'four' },
+  { name: 'fix' },
+  { name: 'six' },
+];

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,7 @@ export default class OracleWrapper {
         this.connectionPool = await oracledb.createPool(this.poolCredentials);
       } catch (err) {
         this.logger.error('Failed to create connectionPool');
+        this.logger.error(err);
         throw err;
       }
     }
@@ -105,6 +106,7 @@ export default class OracleWrapper {
       return connection;
     } catch (err) {
       this.logger.error('Failed to get connection');
+      this.logger.error(err);
       throw err;
     }
   }
@@ -121,6 +123,7 @@ export default class OracleWrapper {
         this.logger.info('Connection pool released');
       } catch (err) {
         this.logger.error('Could not release pool');
+        this.logger.error(err);
         throw err;
       }
     }
@@ -148,6 +151,7 @@ export default class OracleWrapper {
       result = await conn.execute(query, variables, options);
     } catch (err) {
       this.logger.error('Query failed');
+      this.logger.error(err);
       await conn.release();
       throw err;
     }
@@ -167,6 +171,7 @@ export default class OracleWrapper {
       return response;
     } catch (err) {
       this.logger.error('Error fetching data from query');
+      this.logger.error(err);
       await result.resultSet.close();
       await conn.release();
       throw err;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,147 @@
+import util from 'util';
+import oracledb, {
+  Pool,
+  Connection,
+  Result,
+  PoolAttributes,
+} from 'oracledb';
+import { Logger, OracleDBCredentials, OracleDBOptions } from './types';
+
+oracledb.outFormat = oracledb.OUT_FORMAT_OBJECT;
+
+/**
+ * Interface to the Oracle database
+ */
+
+export default class OracleWrapper {
+  /**
+   * A cache alias that will be used to identify this connection
+   * defaults to using the sid from the credentials
+   */
+  private readonly alias: string;
+
+  /**
+   * A logging instance.
+   * Defaults to using the console.
+   */
+  private logger: Logger;
+
+  /**
+   * A set of connections used to communicate with the db server
+   */
+  private connectionPool: Pool;
+
+  /**
+   * The credentials needed to connect to this database
+   */
+  private poolCredentials: PoolAttributes;
+
+  /**
+  * Create a new oracle interface
+  */
+  public constructor(
+    credentials: OracleDBCredentials,
+    options: OracleDBOptions = {}
+  ) {
+    const {
+      host, port, sid, user, password,
+    } = credentials;
+    this.alias = options.alias || sid;
+    this.logger = options.logger || console;
+    this.poolCredentials = {
+      user,
+      password,
+      poolAlias: this.alias,
+      connectionString: `${host}:${port}/${sid}`,
+      poolMin: 0,
+      poolMax: 2,
+      poolIncrement: 1,
+    };
+  }
+
+  /**
+   * Retrieves a connection from the cache pool
+   */
+  public async getConnection(): Promise<Connection> {
+    if (!this.connectionPool) {
+      try {
+        this.connectionPool = await oracledb.createPool(this.poolCredentials);
+      } catch (err) {
+        this.logger.error('Failed to create connectionPool');
+        throw err;
+      }
+    }
+    try {
+      const connection = await oracledb.getConnection(this.alias);
+      return connection;
+    } catch (err) {
+      this.logger.error('Failed to get connection');
+      throw err;
+    }
+  }
+
+  /**
+   * Attempts to close the connection pool, waiting up to 60 seconds for any
+   * active connections to close before forcing it closed.
+   */
+  public async releasePool(): Promise<void> {
+    if (this.connectionPool) {
+      try {
+        await this.connectionPool.close(60);
+        this.connectionPool = null;
+        this.logger.info('Connection pool released');
+      } catch (err) {
+        this.logger.error('Could not release pool');
+        throw err;
+      }
+    }
+  }
+
+  /**
+   * Runs queries against the oracle database
+   * Will process the results in chunks, returning a single results object with
+   * all of the rows returned from the database and a metadata object
+   */
+  public async query<T = Record<string, unknown>>(
+    query: string,
+    variables: Record<string, unknown> = {}
+  ): Promise<T[]> {
+    const ROW_COUNT = 1000;
+    const options = {
+      resultSet: true,
+      prefetchRows: ROW_COUNT,
+    };
+    const conn = await this.getConnection();
+    // Execute Query
+    let result: Result<T>;
+    this.logger.debug(`Executing Query: ${query}`);
+    this.logger.debug(`Parameters: ${util.inspect(variables)}`);
+    try {
+      result = await conn.execute(query, variables, options);
+    } catch (err) {
+      this.logger.error('Query failed');
+      await conn.release();
+      throw err;
+    }
+    // Iterate over response rows, 1000 at a time, creating a complete response
+    // https://jsao.io/2015/07/an-overview-of-result-sets-in-the-nodejs-driver/
+    try {
+      const fetchAndConcat = async (prevRows: T[]): Promise<T[]> => {
+        const rows = await result.resultSet.getRows(ROW_COUNT);
+        if (rows.length) {
+          return fetchAndConcat([...prevRows, ...rows]);
+        }
+        return prevRows;
+      };
+      const response = await fetchAndConcat([]);
+      await result.resultSet.close();
+      await conn.release();
+      return response;
+    } catch (err) {
+      this.logger.error('Error fetching data from query');
+      await result.resultSet.close();
+      await conn.release();
+      throw err;
+    }
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ oracledb.outFormat = oracledb.OUT_FORMAT_OBJECT;
 /**
  * The default options for the Oracle Wrapper
  */
-
 const defaultOptions: OracleDBOptions = {
   logger: console,
   poolMin: 0,
@@ -25,7 +24,6 @@ const defaultOptions: OracleDBOptions = {
 /**
  * Interface to the Oracle database
  */
-
 export default class OracleWrapper {
   /**
    * A cache alias that will be used to identify this connection

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,5 +39,29 @@ export interface OracleDBOptions {
    * An instance of a logger. Uses the console by default.
   */
   logger?: Logger;
-
+  /**
+   * The minimum number of pool connections to make.
+   * Defaults to 0
+   */
+  poolMin?: number;
+  /**
+   * The maximum number of pool connections to make.
+   * Defaults to 2
+   */
+  poolMax?: number;
+  /**
+   * The number of additional pool connections that should be opened at one time
+   * Defaults to 1
+   */
+  poolIncrement?: number;
+  /**
+   * The amount of time to wait for a pool connection to close
+   * Defaults to 60
+   */
+  poolCloseTimeout?: number;
+  /**
+   * The number of rows that should be prefetched when querying the database
+   * Defaults to 1000
+   */
+  prefetchRowCount?: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,43 @@
+export type Loggable = Record<string, unknown>
+| Record<string, unknown>[]
+| (string | number)
+| (string | number)[]
+| Error
+| unknown[];
+
+export interface Logger extends Console{
+  log: (...args: Loggable[]) => void;
+  error: (...args: Loggable[]) => void;
+  warn: (...args: Loggable[]) => void;
+  info: (...args: Loggable[]) => void;
+  http?: (...args: Loggable[]) => void;
+  verbose?: (...args: Loggable[]) => void;
+  debug: (...args: Loggable[]) => void;
+  silly?: (...args: Loggable[]) => void;
+}
+
+export interface OracleDBCredentials {
+  /** Hostname of DB Server */
+  host: string;
+  /** Port number used by db server */
+  port: string;
+  /** Oracle Database Site Identifier */
+  sid: string;
+  /** Database username */
+  user: string;
+  /** Database user password */
+  password: string;
+}
+
+export interface OracleDBOptions {
+  /**
+   * An alias to use for this instances connection in the pool
+   * if none is provided, will use the sid
+   */
+  alias?: string
+  /**
+   * An instance of a logger. Uses the console by default.
+  */
+  logger?: Logger;
+
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,12 +19,16 @@ export interface Logger extends Console{
 export interface OracleDBCredentials {
   /** Hostname of DB Server */
   host: string;
+
   /** Port number used by db server */
   port: string;
+
   /** Oracle Database Site Identifier */
   sid: string;
+
   /** Database username */
   user: string;
+
   /** Database user password */
   password: string;
 }
@@ -35,30 +39,36 @@ export interface OracleDBOptions {
    * if none is provided, will use the sid
    */
   alias?: string
+
   /**
    * An instance of a logger. Uses the console by default.
   */
   logger?: Logger;
+
   /**
    * The minimum number of pool connections to make.
    * Defaults to 0
    */
   poolMin?: number;
+
   /**
    * The maximum number of pool connections to make.
    * Defaults to 2
    */
   poolMax?: number;
+
   /**
    * The number of additional pool connections that should be opened at one time
    * Defaults to 1
    */
   poolIncrement?: number;
+
   /**
    * The amount of time to wait for a pool connection to close
    * Defaults to 60
    */
   poolCloseTimeout?: number;
+
   /**
    * The number of rows that should be prefetched when querying the database
    * Defaults to 1000

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,7 @@
 {
-  "mode": "file",
+  "entryPoints": [
+    "src/index.ts"
+  ],
   "out": "docs",
   "exclude": [
     "**/__tests__/*"


### PR DESCRIPTION
Kind of breaking form by doing this initial implementation in `develop`, but given that it's a very small library I don't think that's a _huge_ issue.

This sets up our `OracleWrapper` class, which is based on the `OracleDB` class that's defined as part of the EAF ETL process, with some small changes aimed at making the class more generalizable. It's also in Typescript now too.

The tests are all pretty basic unit tests. I had spent some time trying to get a oracle database container running for more invovled integration tests but there's just not a great solution for doing that quickly. 